### PR TITLE
Load only the last schedule for which the start time has passed

### DIFF
--- a/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
+++ b/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
@@ -7,13 +7,13 @@ package com.wowza.wms.plugin.streampublisher;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -524,10 +524,6 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 								schedules = new ArrayList<ScheduledItem>();
 								schedulesMap.put(streamName, schedules);
 							}
-							// leave only the last past schedule
-							if (startTime.before(now)) {
-								schedules.removeIf(schedule -> schedule.start.before(now));
-							}
 
 							stream.setSendOnMetadata(passMetaData);
 							stream.setSwitchLog(switchLog);
@@ -541,12 +537,22 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 						}
 						
 					}
-					for(List<ScheduledItem> schedules : schedulesMap.values())
+					schedulesMap.replaceAll((streamName, schedules) ->
 					{
-						Collections.sort(schedules);
-						for(ScheduledItem schedule : schedules)
-							schedule.start();
-					}
+						// future schedules
+						List<ScheduledItem> filteredSchedules = schedules.stream()
+								.sorted()
+								.filter(s -> !s.start.before(now))
+								.collect(Collectors.toList());
+						// find last passed schedule and add it at the beginning of future schedules
+						schedules.stream()
+								.sorted()
+								.filter(s -> s.start.before(now))
+								.reduce((first, second) -> second)
+								.ifPresent(s -> filteredSchedules.add(0, s));
+						return filteredSchedules;
+					});
+					schedulesMap.forEach((streamName, schedules) -> schedules.forEach(ScheduledItem::start));
 				}
 			}
 			catch (Exception ex)

--- a/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
+++ b/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
@@ -337,6 +337,7 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 	@SuppressWarnings("unchecked")
 	public String loadSchedule(IApplicationInstance appInstance) throws Exception
 	{
+		Date now = new Date();
 		WMSProperties serverProps = Server.getInstance().getProperties();
 		WMSProperties props = appInstance.getProperties();
 		synchronized(lock)
@@ -523,6 +524,11 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 								schedules = new ArrayList<ScheduledItem>();
 								schedulesMap.put(streamName, schedules);
 							}
+							// leave only the last past schedule
+							if (startTime.before(now)) {
+								schedules.removeIf(schedule -> schedule.start.before(now));
+							}
+
 							stream.setSendOnMetadata(passMetaData);
 							stream.setSwitchLog(switchLog);
 							stream.setTimesInMilliseconds(timesInMilliseconds);


### PR DESCRIPTION
If the SMIL file contains more than one playlist whose start time has passed, Wowza will load all those playlists at once and enter an unstable state where no stream is available. Meanwhile, there're multiple `Scheduled stream is now live` log messages.

This PR fixes this issue - only the last passed playlist in the SMIL file will be loaded.