### PR TITLE
Add configuration property 'streamPublisherPassPlaylistAttributesAsMetadata'

### DIFF
--- a/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
+++ b/src/com/wowza/wms/plugin/streampublisher/ServerListenerStreamPublisher.java
@@ -90,13 +90,10 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 					playlist.open(stream);
 					logger.info(CLASS_NAME + " Scheduled stream is now live: " + stream.getName());
 
-					if (playlistMetadata != null && playlistMetadata.size() > 0)
-					{
-						AMFDataObj amfData = new AMFDataObj();
-						for (Map.Entry<String, String> m : playlistMetadata.entrySet())
-							amfData.put(m.getKey(), m.getValue());
+					AMFDataObj amfData = new AMFDataObj();
+					playlistMetadata.forEach(amfData::put);
+					if (amfData.size() > 0)
 						stream.getPublisher().getStream().sendDirect("onMetaData", amfData);
-					}
 
 					removeFromList();
 					timer = null;
@@ -495,10 +492,9 @@ public class ServerListenerStreamPublisher implements IServerNotify2
 							if (streamName.length() == 0)
 								continue;
 
-							Map<String, String> playlistMetadata = null;
+							Map<String, String> playlistMetadata = new HashMap<>();
 							if (metadataPlaylistAttributes != null)
 							{
-								playlistMetadata = new HashMap<>();
 								for (String playlistAttribute : metadataPlaylistAttributes.split(","))
 								{
 									if (!e.hasAttribute(playlistAttribute))


### PR DESCRIPTION
Add configuration property `streamPublisherPassPlaylistAttributesAsMetadata` to specify playlist attributes (can be separated by commas) that will be sent in `onMetaData` events.

This PR introduces the ability to add custom playlist attributes and pass them, on playlist start, as timed metadata, to the internal stream. This makes it possible to write other modules that can access those timed metadata and create appropriate DASH event messages (https://www.wowza.com/docs/convert-timed-metadata-from-amf-to-emsg-using-the-wowza-streaming-engine-java-api) or HLS ID3 tags (https://www.wowza.com/docs/how-to-convert-ontextdata-events-in-a-live-or-vod-stream-to-timed-events-id3-tags-in-an-apple-hls-stream).

The example usage would be to mark some playlists as ad blocks:

```
<smil>
	<head>
	</head>
	<body>

		<stream name="test"></stream>

		<playlist name="schedule1" playOnStream="test" repeat="false" scheduled="2000-01-01 00:00:00">
			<video src="mp4:movie.mp4" start="0" length="-1" />
		</playlist>
		<playlist name="schedule2" playOnStream="test" repeat="false" scheduled="2023-02-17 15:36:00" adBreak="true" adBreakType="customType_1">
			<video src="mp4:advertisement_1.mp4" start="0" length="-1" />
			<video src="mp4:advertisement_2.mp4" start="0" length="-1" />
		</playlist>
		<playlist name="schedule3" playOnStream="test" repeat="false" scheduled="2023-02-17 15:37:00">
			<video src="mp4:another_movie.mp4" start="0" length="-1" />
		</playlist>
		<playlist name="schedule4" playOnStream="test" repeat="false" scheduled="2023-02-17 15:36:00" adBreak="true" adBreakType="customType_2">
			<video src="mp4:advertisement_3.mp4" start="0" length="-1" />
			<video src="mp4:advertisement_4.mp4" start="0" length="-1" />
		</playlist>
		<playlist name="schedule5" playOnStream="test" repeat="false" scheduled="2023-02-17 15:40:00">
			<video src="mp4:yet_another_movie.mp4" start="0" length="-1" />
		</playlist>
	</body>
</smil>
```

then set server/application configuration property `streamPublisherPassPlaylistAttributesAsMetadata` to `adBreak,adBreakType` (please notice that attributes can be separated by a comma) and use this information to create SCTE-35 DASH emsg or HLS ID3 tags.
